### PR TITLE
conversion of non utf-8 titles to utf8

### DIFF
--- a/getTitle.js
+++ b/getTitle.js
@@ -16,7 +16,7 @@ function getTitle(url) {
       'User-Agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36'
     }
   };
-  let message =  scrape(options);
+  let message =  JSON.parse(JSON.stringify(scrape(options)));
   return message;
 }
 exports.getTitle = getTitle;


### PR DESCRIPTION
This PR resolves #1 

I've a added workaround conversion of non utf-8 strings to utf-8. It should work without problems.

I hope you merge.
Best regards.